### PR TITLE
Fix logging

### DIFF
--- a/examples/pong/main.rs
+++ b/examples/pong/main.rs
@@ -52,7 +52,7 @@ fn main() -> amethyst::Result<()> {
         .tap(SyncEditorBundle::sync_default_types)
         .tap(|bundle| sync_components!(bundle, Ball, Paddle))
         .tap(|bundle| sync_resources!(bundle, ScoreBoard));
-    // EditorLogger::new(&editor_sync_bundle).start();
+    EditorLogger::new(&editor_sync_bundle).start();
 
     let app_root = application_root_dir();
 

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -10,7 +10,7 @@ use std::marker::PhantomData;
 use std::net::UdpSocket;
 use std::time::Duration;
 use systems::*;
-use types::{ComponentMap, EditorConnection, EntityMessage, ResourceMap};
+use types::*;
 
 /// Bundles all necessary systems for serializing all registered components and resources and
 /// sending them to the editor.
@@ -19,6 +19,7 @@ pub struct SyncEditorBundle {
     read_systems: Vec<Box<dyn RegisterReadSystem>>,
     write_systems: Vec<Box<dyn RegisterWriteSystem>>,
     sender: EditorConnection,
+    receiver: Receiver<SerializedData>,
     component_map: ComponentMap,
     resource_map: ResourceMap,
     socket: UdpSocket,
@@ -91,7 +92,7 @@ macro_rules! read_resources {
 impl SyncEditorBundle {
     /// Construct an empty bundle.
     pub fn new() -> Self {
-        let (sender, _) = crossbeam_channel::unbounded();
+        let (sender, receiver) = crossbeam_channel::unbounded();
         let socket = UdpSocket::bind("0.0.0.0:0").expect("Failed to bind socket");
         socket
             .set_nonblocking(true)
@@ -102,6 +103,7 @@ impl SyncEditorBundle {
             read_systems: Vec::new(),
             write_systems: Vec::new(),
             sender: EditorConnection::new(sender),
+            receiver,
             component_map: HashMap::new(),
             resource_map: HashMap::new(),
             socket,
@@ -238,16 +240,13 @@ impl Default for SyncEditorBundle {
 impl<'a, 'b> SystemBundle<'a, 'b> for SyncEditorBundle {
     fn build(self, dispatcher: &mut DispatcherBuilder<'a, 'b>) -> BundleResult<()> {
         let (entity_sender, entity_receiver) = crossbeam_channel::unbounded::<EntityMessage>();
-        let input_system = EditorInputSystem::new(
+        let receiver_system = EditorReceiverSystem::new(
             self.component_map.clone(),
             self.resource_map.clone(),
             entity_sender,
             self.socket.try_clone().unwrap(),
         );
-        dispatcher.add(input_system, "editor_input_system", &[]);
-
-        let (c, r) = crossbeam_channel::unbounded();
-        let connection = EditorConnection::new(c);
+        dispatcher.add(receiver_system, "editor_receiver_system", &[]);
 
         // All systems must have finished serializing before it can be send to the editor.
         dispatcher.add_barrier();
@@ -263,16 +262,16 @@ impl<'a, 'b> SystemBundle<'a, 'b> for SyncEditorBundle {
         // All systems must have finished editing data before syncing can start.
         dispatcher.add_barrier();
         for read_system in self.read_systems {
-            read_system.register(dispatcher, &connection);
+            read_system.register(dispatcher, &self.sender);
         }
 
-        let sync_system = SyncEditorSystem::from_channel(
-            r,
+        let sender_system = EditorSenderSystem::from_channel(
+            self.receiver,
             Duration::from_millis(200),
-            self.socket.try_clone().ok().unwrap(),
+            self.socket,
         );
         dispatcher.add_barrier();
-        dispatcher.add(sync_system, "sync_editor_system", &[]);
+        dispatcher.add(sender_system, "editor_sender_system", &[]);
 
         Ok(())
     }

--- a/src/systems/editor_receiver.rs
+++ b/src/systems/editor_receiver.rs
@@ -5,7 +5,9 @@ use std::net::UdpSocket;
 use std::str;
 use types::{ComponentMap, EntityMessage, IncomingComponent, IncomingMessage, ResourceMap};
 
-pub struct EditorInputSystem {
+/// The system in charge of reading and dispatching incoming messages from
+/// the editor.
+pub struct EditorReceiverSystem {
     socket: UdpSocket,
 
     // Map containing channels used to send incoming serialized component/resource data from the
@@ -17,19 +19,19 @@ pub struct EditorInputSystem {
     incoming_buffer: Vec<u8>,
 }
 
-impl EditorInputSystem {
+impl EditorReceiverSystem {
     pub fn new(
         component_map: ComponentMap,
         resource_map: ResourceMap,
         entity_handler: Sender<EntityMessage>,
         socket: UdpSocket,
-    ) -> EditorInputSystem {
+    ) -> EditorReceiverSystem {
         // Create the socket used for communicating with the editor.
         //
         // NOTE: We set the socket to nonblocking so that we don't block if there are no incoming
         // messages to read. We `expect` on the call to `set_nonblocking` because the game will
         // hang if the socket is still set to block when the game runs.
-        EditorInputSystem {
+        EditorReceiverSystem {
             socket,
             component_map,
             resource_map,
@@ -39,7 +41,7 @@ impl EditorInputSystem {
     }
 }
 
-impl<'a> System<'a> for EditorInputSystem {
+impl<'a> System<'a> for EditorReceiverSystem {
     type SystemData = Entities<'a>;
 
     fn run(&mut self, entities: Self::SystemData) {
@@ -152,7 +154,8 @@ impl<'a> System<'a> for EditorInputSystem {
                             self.entity_handler
                                 .send(EntityMessage::Destroy(
                                     entities.iter().map(|e| e.id).collect(),
-                                )).expect("Disconnected from entity handler system");
+                                ))
+                                .expect("Disconnected from entity handler system");
                         }
                     }
                 }

--- a/src/systems/editor_sender.rs
+++ b/src/systems/editor_sender.rs
@@ -9,9 +9,8 @@ use types::SerializedData;
 
 const MAX_PACKET_SIZE: usize = 32 * 1024;
 
-/// A system that is in charge of coordinating a number of serialization systems and sending
-/// their results to the editor.
-pub struct SyncEditorSystem {
+/// The system in charge of sending updated state data to the editor process.
+pub struct EditorSenderSystem {
     receiver: Receiver<SerializedData>,
     socket: UdpSocket,
 
@@ -21,7 +20,7 @@ pub struct SyncEditorSystem {
     scratch_string: String,
 }
 
-impl SyncEditorSystem {
+impl EditorSenderSystem {
     pub fn from_channel(
         receiver: Receiver<SerializedData>,
         send_interval: Duration,
@@ -33,7 +32,7 @@ impl SyncEditorSystem {
         // messages to read. We `expect` on the call to `set_nonblocking` because the game will
         // hang if the socket is still set to block when the game runs.
         let scratch_string = String::with_capacity(MAX_PACKET_SIZE);
-        Self {
+        EditorSenderSystem {
             receiver,
             socket,
 
@@ -45,7 +44,7 @@ impl SyncEditorSystem {
     }
 }
 
-impl<'a> System<'a> for SyncEditorSystem {
+impl<'a> System<'a> for EditorSenderSystem {
     type SystemData = Entities<'a>;
 
     fn run(&mut self, entities: Self::SystemData) {

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,15 +1,15 @@
-mod editor_input;
+mod editor_receiver;
+mod editor_sender;
 mod entity_handler;
 mod read_component;
 mod read_resource;
-mod sync_editor;
 mod write_component;
 mod write_resource;
 
-pub(crate) use self::editor_input::EditorInputSystem;
+pub(crate) use self::editor_receiver::EditorReceiverSystem;
+pub(crate) use self::editor_sender::EditorSenderSystem;
 pub(crate) use self::entity_handler::EntityHandlerSystem;
 pub(crate) use self::read_component::ReadComponentSystem;
 pub(crate) use self::read_resource::ReadResourceSystem;
-pub(crate) use self::sync_editor::SyncEditorSystem;
 pub(crate) use self::write_component::WriteComponentSystem;
 pub(crate) use self::write_resource::WriteResourceSystem;

--- a/src/types.rs
+++ b/src/types.rs
@@ -78,12 +78,12 @@ pub struct EditorConnection {
 
 impl EditorConnection {
     /// Construct a connection to the editor via sending messages to the [`SyncEditorSystem`].
-    pub fn new(sender: Sender<SerializedData>) -> Self {
+    pub(crate) fn new(sender: Sender<SerializedData>) -> Self {
         Self { sender }
     }
 
     /// Send serialized data to the editor.
-    pub fn send_data(&self, data: SerializedData) {
+    pub(crate) fn send_data(&self, data: SerializedData) {
         self.sender
             .send(data)
             .expect("Disconnected from editor sync system");


### PR DESCRIPTION
Fix an issue with the way the `EditorConnection` was setup within `SyncEditorBundle` that was causing log output to panic. Also, make some changes to the naming of systems that are in charge of sending/receiving data to/from the editor in order to make their purposes more clear.

Fixes #41 