### PR TITLE
Refactor to prevent race conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ use tap::*;
 fn main() -> Result<(), amethyst::Error> {
     // Create a `SyncEditorBundle` which will register all necessary systems to serialize and send
     // data to the editor.
-    let editor_bundle = SyncEditorBundle::new()
+    let editor_bundle = SyncEditorBundle::default()
         // Register the default types from the engine.
         .tap(SyncEditorBundle::sync_default_types)
         // Register the components and resources specified above.

--- a/examples/pong/main.rs
+++ b/examples/pong/main.rs
@@ -46,7 +46,7 @@ fn main() -> amethyst::Result<()> {
 
     amethyst::start_logger(Default::default());
 
-    let editor_sync_bundle = SyncEditorBundle::new()
+    let editor_sync_bundle = SyncEditorBundle::default()
         .tap(SyncEditorBundle::sync_default_types)
         .tap(|bundle| sync_components!(bundle, Ball, Paddle))
         .tap(|bundle| sync_resources!(bundle, ScoreBoard));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,9 @@
 //! conjuction with the helper macros to succinctly register a variety of
 //! custom types.
 //!
+//! **It is highly recommended to register the bundle last, to ensure the editor
+//! receives values after all systems have updated them**
+//!
 //! # Examples
 //!
 //! ```
@@ -47,7 +50,7 @@
 //! # fn main() -> Result<(), amethyst::Error> {
 //! // Create a SyncEditorBundle which will create all necessary systems to send the components
 //! // to the editor.
-//! let editor_sync_bundle = SyncEditorBundle::new()
+//! let editor_sync_bundle = SyncEditorBundle::default()
 //!
 //!     // Register the default types from the engine.
 //!     .tap(SyncEditorBundle::sync_default_types)
@@ -90,7 +93,7 @@
 //! ```
 //!
 //! [`SyncEditorBundle`]: ./struct.SyncEditorBundle.html
-//! [`SyncEditorBundle::new`]: ./struct.SyncEditorBundle.html#method.new
+//! [`SyncEditorBundle::default()`]: ./struct.SyncEditorBundle.html#method.default
 //! [`sync_components`]: ./macro.sync_components.html
 //! [`read_components`]: ./macro.read_components.html
 //! [`sync_resources`]: ./macro.sync_resources.html

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -39,7 +39,7 @@ impl SimpleState for TestState {
 }
 
 fn run_world(num_entities: usize) -> amethyst::Result<()> {
-    let editor_sync_bundle = SyncEditorBundle::new();
+    let editor_sync_bundle = SyncEditorBundle::default();
     let game_data = GameDataBuilder::default().with_bundle(editor_sync_bundle)?;
     let mut game = Application::build(".", TestState::new(num_entities))?.build(game_data)?;
     game.run();

--- a/tests/registration.rs
+++ b/tests/registration.rs
@@ -11,7 +11,7 @@ use tap::*;
 
 #[test]
 fn empty() {
-    let editor_bundle = SyncEditorBundle::new().tap(SyncEditorBundle::sync_default_types);
+    let editor_bundle = SyncEditorBundle::default().tap(SyncEditorBundle::sync_default_types);
 
     let _ = GameDataBuilder::default().with_bundle(editor_bundle);
 }
@@ -25,7 +25,7 @@ fn register_component() {
         type Storage = DenseVecStorage<Self>;
     }
 
-    let editor_bundle = SyncEditorBundle::new()
+    let editor_bundle = SyncEditorBundle::default()
         .tap(SyncEditorBundle::sync_default_types)
         .tap(|bundle| sync_components!(bundle, Foo));
 

--- a/tests/resource.rs
+++ b/tests/resource.rs
@@ -38,7 +38,7 @@ fn serialize_resource() -> amethyst::Result<()> {
     }
 
     let editor_sync_bundle =
-        SyncEditorBundle::new().tap(|bundle| sync_resources!(bundle, SimpleResource));
+        SyncEditorBundle::default().tap(|bundle| sync_resources!(bundle, SimpleResource));
 
     let game_data = GameDataBuilder::default().with_bundle(editor_sync_bundle)?;
     let mut game = Application::build(".", TestState::default())?.build(game_data)?;
@@ -69,7 +69,7 @@ fn missing_resource() -> amethyst::Result<()> {
     }
 
     let editor_sync_bundle =
-        SyncEditorBundle::new().tap(|bundle| sync_resources!(bundle, SimpleResource));
+        SyncEditorBundle::default().tap(|bundle| sync_resources!(bundle, SimpleResource));
 
     let game_data = GameDataBuilder::default().with_bundle(editor_sync_bundle)?;
     let mut game = Application::build(".", TestState::default())?.build(game_data)?;


### PR DESCRIPTION
## Warning, this is a breaking change
This refactor adds more synchronous behaviour to prevent desync of the Editor and Game.
The signature of `SyncEditorBundle::new()` has been changed.

- Reorder registrations and add system dependencies
- Add `send_duration` and Bind Address parameters to `new()`
- Move current duration and address to `default` impl
- Fixed and updated tests
- Updated documentation